### PR TITLE
Fix reloads full clip at once attribute

### DIFF
--- a/scripts/vscripts/popextensions/customattributes.nut
+++ b/scripts/vscripts/popextensions/customattributes.nut
@@ -1337,21 +1337,23 @@ function CustomAttributes::ReloadsFullClipAtOnce(player, items) {
         if (wep == null) return
 
         local scope = player.GetScriptScope()
+        scope.lastClip <- wep.Clip1() // thanks to seelpit for detectreload logic
 
         scope.PlayerThinkTable[format("ReloadFullClipAtOnce_%d_%d", player.GetScriptScope().userid,  wep.entindex())] <- function() {
 
             if (player.GetActiveWeapon() != wep) return
 
-            local oldClip1 = wep.Clip1()
-            if (wep.Clip1() != wep.GetMaxClip1()) {
-                scope.isreloading <- true
-            }
+            local currentClip = wep.Clip1()
+            local wepSlot = wep.GetSlot() + 1
 
-            if (("isreloading" in scope) && scope.isreloading && wep.Clip1() != oldClip1) {
-
+            if (currentClip > lastClip) {
                 wep.SetClip1(wep.GetMaxClip1())
-                scope.isreloading = false
+                local ammoDeducted = (wep.GetMaxClip1() - currentClip)
+                local currentAmmo = GetPropIntArray(player, "m_iAmmo", wepSlot)
+                SetPropIntArray(player, "m_iAmmo", currentAmmo - ammoDeducted, wepSlot)
+                currentClip = wep.Clip1()
             }
+            lastClip = currentClip
         }
     }
 }
@@ -1792,7 +1794,7 @@ function CustomAttributes::AddAttr(player, attr = "", value = 0, items = {}) {
 
             case "reloads full clip at once":
                 CustomAttributes.ReloadsFullClipAtOnce(player, items)
-                scope.attribinfo[attr] <- "weapon reloads entire clip at once"
+                scope.attribinfo[attr] <- "This weapon reloads its entire clip at once."
             break
 
             case "fire full clip at once":

--- a/scripts/vscripts/popextensions/customattributes.nut
+++ b/scripts/vscripts/popextensions/customattributes.nut
@@ -1342,11 +1342,12 @@ function CustomAttributes::ReloadsFullClipAtOnce(player, items) {
 
             if (player.GetActiveWeapon() != wep) return
 
-            if (wep.Clip1() == 0)
+            local oldClip1 = wep.Clip1()
+            if (wep.Clip1() != wep.GetMaxClip1()) {
                 scope.isreloading <- true
+            }
 
-
-            if (("isreloading" in scope) && scope.isreloading && wep.Clip1() != 0) {
+            if (("isreloading" in scope) && scope.isreloading && wep.Clip1() != oldClip1) {
 
                 wep.SetClip1(wep.GetMaxClip1())
                 scope.isreloading = false


### PR DESCRIPTION
Now works for all clip sizes and properly deducts reserve ammo count like how pistol reloads work.

One thing I can't get it to work is that some clip weapons (eg shotgun) reload once more even after fully reloaded, effectively eating away one reserve ammo; whilst some weapons (eg rocket launcher) don't have this issue and works properly, but this is really minor so I decided to leave it in.

Thanks seelpit for help