### PR TITLE
Add popext_warpaint, update ClassLimits

### DIFF
--- a/scripts/vscripts/popextensions/missionattributes.nut
+++ b/scripts/vscripts/popextensions/missionattributes.nut
@@ -2298,16 +2298,16 @@ if (!("ScriptUnloadTable" in ROOT)) ::ScriptUnloadTable <- {}
 
 				local player = GetPlayerFromUserID(params.userid)
 				if (player.IsBotOfType(TF_BOT_TYPE)) return
-				// Note that player_changeclass fires before swap occurs
-				// This means that GetPlayerClass() can be used to get the previous player class,
+				// Note that player_changeclass fires before a class swap actually occurs.
+				// This means that player.GetPlayerClass() can be used to get the previous class,
 				//  and that PopExtUtil::PlayerClassCount() will return the current class array.
 				local classcount = PopExtUtil.PlayerClassCount()[params["class"]] + 1
 				if (params["class"] in value && classcount > value[params["class"]]) {
 					PopExtUtil.ForceChangeClass(player, player.GetPlayerClass())
 					if (value[params["class"]] == 0)
-						PopExtUtil.ShowMessage(format("%s is not allowed on this mission.", PopExtUtil.capwords(PopExtUtil.Classes[params["class"]])))
+						PopExtUtil.ShowMessage(format("%s is not allowed on this mission.", PopExtUtil.ClassesCaps[params["class"]]))
 					else
-						PopExtUtil.ShowMessage(format("%s is limited to %i for this mission.", PopExtUtil.capwords(PopExtUtil.Classes[params["class"]]), value[params["class"]]))
+						PopExtUtil.ShowMessage(format("%s is limited to %i for this mission.", PopExtUtil.ClassesCaps[params["class"]], value[params["class"]]))
 					switch(params["class"]) {
 						case TF_CLASS_SCOUT: EmitSoundOn("Scout.No03", player); break
 						case TF_CLASS_SOLDIER: EmitSoundOn("Soldier.No01", player); break
@@ -2319,15 +2319,33 @@ if (!("ScriptUnloadTable" in ROOT)) ::ScriptUnloadTable <- {}
 						case TF_CLASS_SNIPER: EmitSoundOn("Sniper.No04", player); break
 						case TF_CLASS_SPY: EmitSoundOn("Spy.No02", player); break
 						case TF_CLASS_CIVILIAN: EmitSoundOn("Scout.No03", player); break
-						default: break
 					}
 				}
 			}
 
+			// Accept string identifiers for classes to limit.
+			foreach (k, v in value) {
+				if (typeof k != "string") continue
+				printl(k + " " + v)
+				switch (k.tolower()) {
+					case "scout": value[TF_CLASS_SCOUT] <- v; delete value[k]; break
+					case "soldier": value[TF_CLASS_SOLDIER] <- v; delete value[k]; break
+					case "pyro": value[TF_CLASS_PYRO] <- v; delete value[k]; break
+					case "demo": value[TF_CLASS_DEMOMAN] <- v; delete value[k]; break
+					case "demoman": value[TF_CLASS_DEMOMAN] <- v; delete value[k]; break
+					case "heavy": value[TF_CLASS_HEAVYWEAPONS] <- v; delete value[k]; break
+					case "heavyweapons": value[TF_CLASS_HEAVYWEAPONS] <- v; delete value[k]; break
+					case "engineer": value[TF_CLASS_ENGINEER] <- v; delete value[k]; break
+					case "medic": value[TF_CLASS_MEDIC] <- v; delete value[k]; break
+					case "sniper": value[TF_CLASS_SNIPER] <- v; delete value[k]; break
+					case "spy": value[TF_CLASS_SPY] <- v; delete value[k]; break
+					case "civilian": value[TF_CLASS_CIVILIAN] <- v; delete value[k]; break
+				}
+			}
+
 			MissionAttributes.ClassLimits <- value
-			// Dump overflow players to free classes on wave init
+			// Dump overflow players to free classes on wave init.
 			EntFireByHandle(PopExtUtil.GameRules, "RunScriptCode", @"
-				PopExtUtil.SwitchToFirstValidWeapon(self)
 				local initcounts = PopExtUtil.PlayerClassCount()
 				local classes = array(TF_CLASS_COUNT_ALL, 0)
 				foreach (player in PopExtUtil.HumanArray) {
@@ -2345,7 +2363,7 @@ if (!("ScriptUnloadTable" in ROOT)) ::ScriptUnloadTable <- {}
 						}
 						if (nobreak) {
 							PopExtUtil.ForceChangeClass(player, RandomInt(1, 9))
-							MissionAttributes.ParseError(`ClassLimits could not find a free class slot`)
+							MissionAttributes.ParseError(`ClassLimits could not find a free class slot.`)
 							break
 						}
 					}

--- a/scripts/vscripts/popextensions/missionattributes.nut
+++ b/scripts/vscripts/popextensions/missionattributes.nut
@@ -2550,6 +2550,7 @@ if (!("ScriptUnloadTable" in ROOT)) ::ScriptUnloadTable <- {}
 	}
 
 	// TODO: implement a try catch raise system instead of this
+	// TODO: We should move this to popextensions_main.nut so we can have better error logging through the whole library.
 
 	// Raises an error if the user passes an index that is out of range.
 	// Example: Allowed values are 1-2, but user passed 3.

--- a/scripts/vscripts/popextensions/tags.nut
+++ b/scripts/vscripts/popextensions/tags.nut
@@ -759,15 +759,16 @@ local popext_funcs = {
 	 *   0.8 = Well-Worn
 	 *   1.0 = Battle Scarred
 	 *
-	 * The following popfile example would apply a Battle Scarred Macaw Masked warpaint to
-	 * a bot soldier's rocket launcher, with a "White Gem" seed.
+	 * The following popfile example with all optional parameters provided would apply a
+	 * Battle Scarred Macaw Masked warpaint to a bot soldier's rocket launcher, with the
+	 * "White Gem" seed set.
 	 *
 	 * TFBot
 	 * {
 	 *     Class Soldier
 	 *     Attributes IgnoreFlag
 	 *     Item "Upgradeable TF_WEAPON_ROCKETLAUNCHER"
-	 *     Tag "popext_warpaint{ slot = 0, idx = 303, wear = 1.0, seed = `8873643875`}"
+	 *     Tag "popext_warpaint{ idx = 303, slot = 0, wear = 1.0, seed = `8873643875`}"
 	 * }
 	 *
 	 * Implementation note: seeds can be passed as strings or integers on 64-bit servers

--- a/scripts/vscripts/popextensions/tags.nut
+++ b/scripts/vscripts/popextensions/tags.nut
@@ -744,6 +744,105 @@ local popext_funcs = {
 		}
 	}
 
+	/**
+	 * Applies a warpaint to give a bot a decorated weapon.
+	 *
+	 * @param idx int		Warpaint index to apply to the weapon.
+	 * @param slot int?		Slot to apply to paintkit to (Default: Bot's active weapon on spawn).
+	 * @param wear flt?		Texture wear to apply to the warpaint (Default: Refers to "set_item_texture_wear", 0.0 if not set).
+	 * @param seed int?		Warpaint seed to use (Default: Refers to "custom_paintkit_seed_lo" and "custom_paintkit_seed_hi", none if not set).
+	 *
+	 *  Texture wear reference values:
+	 *   0.2 = Factory New
+	 *   0.4 = Minimal Wear
+	 *   0.6 = Field-Tested
+	 *   0.8 = Well-Worn
+	 *   1.0 = Battle Scarred
+	 *
+	 * The following popfile example would apply a Battle Scarred Macaw Masked warpaint to
+	 * a bot soldier's rocket launcher, with a "White Gem" seed.
+	 *
+	 * TFBot
+	 * {
+	 *     Class Soldier
+	 *     Attributes IgnoreFlag
+	 *     Item "Upgradeable TF_WEAPON_ROCKETLAUNCHER"
+	 *     Tag "popext_warpaint{ slot = 0, idx = 303, wear = 1.0, seed = `8873643875`}"
+	 * }
+	 *
+	 * Implementation note: seeds can be passed as strings or integers on 64-bit servers
+	 * (integers are preferable), but they *must* be passed as strings on 32-bit servers.
+	 **/
+	popext_warpaint = function(bot, args) {
+		local weapon = null
+		local idx = args.idx.tointeger()
+
+		// Get the weapon in the slot provided.
+		if ("slot" in args && args.slot != null) {
+			local slot = args.slot.tointeger()
+
+			local nobreak = true
+			for (local i = 0; i < SLOT_COUNT; ++i) {
+				weapon = GetPropEntityArray(bot, "m_hMyWeapons", i)
+				if (weapon == null || weapon.GetSlot() != slot) continue
+				nobreak = false
+				break
+			}
+			if (weapon == null || nobreak == true) {
+				ParseError("Bot with popext_warpaint tag did not have a valid weapon in slot '%i'.")
+				return
+			}
+		}
+		// If no slot index is provided, use the bot's active weapon.
+		else weapon = bot.GetActiveWeapon()
+
+		// Set paintkit_proto_def_index as a float value (it is set incorrectly by the game).
+		weapon.AddAttribute("paintkit_proto_def_index", casti2f(idx), -1)
+
+		// Set item texture wear.
+		local wear = "wear" in args ? args.wear.tofloat() : weapon.GetAttribute("set_item_texture_wear", 0.0)
+		weapon.AddAttribute("set_item_texture_wear", wear, -1)
+
+		if (_intsize_ >= 8 && "seed" in args) {
+			local seed = args.seed.tostring()
+
+			// Simple operation if we are on 64-bit.
+			if (_intsize_ == 8) {
+				// This will overflow a Squirrel UInt, but we don't care since we only want the bits, the value is irrelevant.
+				seed = seed.tointeger()
+				weapon.AddAttribute("custom_paintkit_seed_lo", casti2f(seed & 0xFFFFFFFF), -1)
+				weapon.AddAttribute("custom_paintkit_seed_hi", casti2f(seed >> 32), -1)
+			}
+			// More involved if we are on 32-bit.
+			// DEPRECATED: This will be removed once 32-bit TF2 support is dropped.
+			else {
+				// Decompose a 64-bit decimal seed string in to four 16-bit integers,
+				//  and then compile the resulting integers to two 32 bit integers.
+				seed = seed.tostring()
+				local strlen = seed.len()
+				local digitstore = array(strlen, 0)
+
+				for (local i = 0; i < strlen; ++i) {
+					local carry = seed[i] - 48
+					local tmp = 0
+
+					for (local i = (strlen - 1); (i >= 0); --i) {
+						tmp = (digitstore[i] * 10) + carry
+						digitstore[i] = tmp & 0xFFFF
+						carry = tmp >> 16
+					}
+				}
+
+				weapon.AddAttribute("custom_paintkit_seed_lo", casti2f(
+					digitstore[strlen - 2] << 16 | digitstore[strlen - 1]
+				), -1)
+				weapon.AddAttribute("custom_paintkit_seed_hi", casti2f(
+					digitstore[strlen - 4] << 16 | digitstore[strlen - 3]
+				), -1)
+			}
+		}
+	}
+
 	popext_dropweapon = function(bot, args) {
 
 		bot.GetScriptScope().DeathHookTable.DropWeaponDeath <- function(params) {
@@ -1119,8 +1218,22 @@ local popext_funcs = {
 			}
 
 		} else if (separator == "{") {
-
-			compilestring(format("::__popexttagstemp <- { %s", splittag[1]))()
+			// Allow inputting strings in new-style tags using backticks.
+			local arr = split(splittag[1], "`")
+			local end = arr.len() - 1
+			if (end > 1) {
+				local str = ""
+				foreach (i, sub in arr) {
+					if (i == end) {
+						str += sub
+						break
+					}
+					str += sub + "\""
+				}
+				compilestring(format("::__popexttagstemp <- { %s", str))()
+			} else {
+				compilestring(format("::__popexttagstemp <- { %s", splittag[1]))()
+			}
 
 			foreach(k, v in ::__popexttagstemp) tagtable[k] <- v
 

--- a/scripts/vscripts/popextensions/tags.nut
+++ b/scripts/vscripts/popextensions/tags.nut
@@ -790,7 +790,13 @@ local popext_funcs = {
 				break
 			}
 			if (weapon == null || nobreak == true) {
-				ParseError("Bot with popext_warpaint tag did not have a valid weapon in slot '%i'.")
+				local e = format("popext_warpaint: Bot '%%s' does not have a weapon in slot %i.", slot)
+				// We must delay the error by 1 tick in order to get the proper bot name.
+				EntFireByHandle(bot, "RunScriptCode",
+					format(@"local e = format(`%s`, GetPropString(self, `m_szNetname`))
+					ClientPrint(null, HUD_PRINTCONSOLE, e)
+					if (!GetListenServerHost()) printl(e)", e)
+				, SINGLE_TICK, null, null)
 				return
 			}
 		}
@@ -804,7 +810,7 @@ local popext_funcs = {
 		local wear = "wear" in args ? args.wear.tofloat() : weapon.GetAttribute("set_item_texture_wear", 0.0)
 		weapon.AddAttribute("set_item_texture_wear", wear, -1)
 
-		if (_intsize_ >= 8 && "seed" in args) {
+		if ("seed" in args) {
 			local seed = args.seed.tostring()
 
 			// Simple operation if we are on 64-bit.

--- a/scripts/vscripts/popextensions/tags.nut
+++ b/scripts/vscripts/popextensions/tags.nut
@@ -766,7 +766,6 @@ local popext_funcs = {
 	 * TFBot
 	 * {
 	 *     Class Soldier
-	 *     Attributes IgnoreFlag
 	 *     Item "Upgradeable TF_WEAPON_ROCKETLAUNCHER"
 	 *     Tag "popext_warpaint{ idx = 303, slot = 0, wear = 1.0, seed = `8873643875`}"
 	 * }

--- a/scripts/vscripts/popextensions/util.nut
+++ b/scripts/vscripts/popextensions/util.nut
@@ -5,7 +5,7 @@
 	BotArray = []
 	PlayerArray = []
 	Classes = ["", "scout", "sniper", "soldier", "demo", "medic", "heavy", "pyro", "spy", "engineer", "civilian"] //make element 0 a dummy string instead of doing array + 1 everywhere
-	ClassesCaps = ["", "Scout", "Sniper", "Soldier", "Demo", "Medic", "Heavy", "Pyro", "Spy", "Engineer", "Civilian"] //make element 0 a dummy string instead of doing array + 1 everywhere
+	ClassesCaps = ["", "Scout", "Sniper", "Soldier", "Demoman", "Medic", "Heavy", "Pyro", "Spy", "Engineer", "Civilian"] //make element 0 a dummy string instead of doing array + 1 everywhere
 	Slots   = ["slot_primary", "slot_secondary", "slot_melee", "slot_utility", "slot_building", "slot_pda", "slot_pda2"]
 	IsWaveStarted = false //check a global variable instead of accessing a netprop every time to check if we are between waves.
 	AllNavAreas = {}


### PR DESCRIPTION
- ClassLimits
  - Now accepts string parameters for classes (such as `"Scout"` instead of `[TF_CLASS_SCOUT]`).
- popext_warpaint
  - New bot tag that give a bot a decorated weapon.
  - To give a bot a White Gem, Battle Scarred, Macaw Masked Rocket Launcher:
    ```Valve-Data-Format
    TFBot {
        Class Soldier
        Item "Upgradeable TF_WEAPON_ROCKETLAUNCHER"
        Tag "popext_warpaint{ idx = 303, slot = 0, wear = 1.0, seed = `8873643875`}"
    }
    ```