### PR TITLE
Update customweapons.nut to not use ExtraItems

### DIFF
--- a/scripts/vscripts/popextensions/customweapons.nut
+++ b/scripts/vscripts/popextensions/customweapons.nut
@@ -1,7 +1,7 @@
 //By washy
 //credit to ficool2, Yaki and LizardofOz
 //special thanks to fellen for help on tf_item_map.nut
-ExtraItems <-
+ExtraItems <-	// example on how weapons are listed, use ::CustomItems instead of ExtraItems
 {
 	"Wasp Launcher" :
 	{
@@ -118,10 +118,10 @@ ExtraItems <-
 		local item_slot = null
 
 		//if item is a custom item, overwrite itemname with OriginalItemName
-		if (itemname in ExtraItems)
+		if (itemname in CustomItems)
 		{
-			extraitem = ExtraItems[itemname]
-			itemname = ExtraItems[itemname].OriginalItemName
+			extraitem = CustomItems[itemname]
+			itemname = CustomItems[itemname].OriginalItemName
 		}
 
 		if (itemname in PopExtItems)


### PR DESCRIPTION
Looking up ExtraItems, which exists in the script, means it can only use weapons listed within the script. Changing it to CustomItems instead allows outside scripts to be used.
![tumblr_oeg2d7RKZO1sh0iino2_540](https://github.com/user-attachments/assets/3df9a6d6-0d86-43da-84d9-e36ef6437d61)
