### PR TITLE
Fixes and enhances FiresMilkBolt

### DIFF
--- a/scripts/vscripts/popextensions/customattributes.nut
+++ b/scripts/vscripts/popextensions/customattributes.nut
@@ -16,7 +16,10 @@
 
 		"fires milk bolt": function(player, items, attr, value) {
 			CustomAttributes.FiresMilkBolt(player, items, value)
-			player.GetScriptScope().attribinfo[attr] <- format("Secondary attack: fires a bolt that applies milk for %.2f seconds. Regenerates every %.2f seconds.", value.duration.tofloat(), value.recharge.tofloat())
+			local duration = 10.0, recharge = 20.0
+			if ("duration" in value) duration = value.duration
+			if ("recharge" in value) recharge = value.recharge
+			player.GetScriptScope().attribinfo[attr] <- format("Secondary attack: fires a bolt that applies milk for %.1f seconds. Regenerates every %.1f seconds.", duration.tofloat(), recharge.tofloat())
 		}
 
 		"mod teleporter speed boost": function(player, items, attr, value) {


### PR DESCRIPTION
Fixes and enhances the behaviour of `fires milk bolt` so that it more accurately resembles the rafmod attribute now.

Popfile usage is shown below. Personally think that this syntax should be what will be primarily supported in the future, much like the transition from pipe syntax to table syntax of tags.nut. This is what this PR is actually about: not just a random fix but possibly a start of a series of future changes.
```
ItemAttributes = {
	tf_weapon_soda_popper = {
		"fires milk bolt": {duration = 8, recharge = 10}
	}
}
```

If popfile writer screws up with the definition the attribute will default into mad milk default params of `duration` and `recharge`. For example:
```
"fires milk bolt": 1
```
will set the attribute into using 10 as the duration, 20 as the recharge. Hud hints display accordingly.

Known issue:
- ~~Will break if not both `duration` and `recharge` is specified. This has something to do with `attribinfo`. Could do a lazy quadruple if/elseif checks but there probably is a better way to allow for default values.~~ Fixed in latest commit