### PR TITLE
Fix of homing projectiles in tags.nut

### DIFF
--- a/scripts/vscripts/popextensions/tags.nut
+++ b/scripts/vscripts/popextensions/tags.nut
@@ -1014,9 +1014,9 @@ local popext_funcs = {
 		bot.GetScriptScope().PlayerThinkTable.HomingProjectileScanner <- function() {
 
 			for (local projectile; projectile = FindByClassname(projectile, "tf_projectile_*");) {
-				if (projectile.GetOwner() != bot || !this.IsValidProjectile(projectile, PopExtUtil.HomingProjectiles)) continue
+				if (projectile.GetOwner() != bot || !Homing.IsValidProjectile(projectile, PopExtUtil.HomingProjectiles)) continue
 				// Any other parameters needed by the projectile thinker can be set here
-				this.AttachProjectileThinker(projectile, speed_mult, turn_power, ignoreDisguisedSpies, ignoreStealthedSpies)
+				Homing.AttachProjectileThinker(projectile, speed_mult, turn_power, ignoreDisguisedSpies, ignoreStealthedSpies)
 			}
 		}
 
@@ -1535,13 +1535,13 @@ local popext_funcs = {
 		//this should be added in globalfixes.nut but sometimes this code tries to run before the table is created
 		if (!("ProjectileThinkTable" in projectile_scope)) projectile_scope.ProjectileThinkTable <- {}
 
-		projectile_scope.ProjectileThinkTable.HomingProjectileThink <- this.HomingProjectileThink
+		projectile_scope.ProjectileThinkTable.HomingProjectileThink <- Homing.HomingProjectileThink
 	}
 
 	function HomingProjectileThink() {
-		local new_target = this.SelectVictim(self)
-		if (new_target != null && this.IsLookingAt(self, new_target))
-			this.FaceTowards(new_target, self, projectile_speed)
+		local new_target = Homing.SelectVictim(self)
+		if (new_target != null && Homing.IsLookingAt(self, new_target))
+			Homing.FaceTowards(new_target, self, projectile_speed)
 	}
 
 	function SelectVictim(projectile) {


### PR DESCRIPTION
Should fix an error:

AN ERROR HAS OCCURRED [the index 'IsValidProjectile' does not exist]

CALLSTACK
*FUNCTION [unknown()] tags.nut line [1017]
*FUNCTION [call()] NATIVE line [-1]
*FUNCTION [unknown()] popextensions_main.nut line [162]

LOCALS
[bot] INSTANCE
[speed_mult] 1
[turn_power] 1
[ignoreDisguisedSpies] 0
[ignoreStealthedSpies] 2147483647
[projectile] INSTANCE
[this] TABLE
[scope] TABLE
[func] CLOSURE
[name] "HomingProjectileScanner"
[this] TABLE