### PR TITLE
popextensions_main: teamplay_round_start -> recalculate_holidays

### DIFF
--- a/scripts/vscripts/popextensions_main.nut
+++ b/scripts/vscripts/popextensions_main.nut
@@ -195,7 +195,8 @@ if (!("_AddThinkToEnt" in _root))
 			PopExtMain.PlayerCleanup(player)
 		}
 
-		function OnGameEvent_teamplay_round_start(params) {
+		function OnGameEvent_recalculate_holidays(_) {
+			if (GetRoundState() != GR_STATE_PREROUND) return
 
 			//clean up all wearables that are not owned by a player or a bot
 			for (local wearable; wearable = FindByClassname(wearable, "tf_wearable*");)


### PR DESCRIPTION
We should use `recalculate_holidays` instead here, as we also hook `post_inventory_application`, which fires before `teamplay_round_start` and can cause errors on mission swap. `recalculate_holidays` fires before `post_inventory_application` and thus avoids this problem.