### PR TITLE
Revert #63

### DIFF
--- a/scripts/vscripts/popextensions/util.nut
+++ b/scripts/vscripts/popextensions/util.nut
@@ -1636,6 +1636,7 @@
 		}
 
 		function OnGameEvent_post_inventory_application(params) {
+			if (GetRoundState() == GR_STATE_PREROUND) return
 
 			local player = GetPlayerFromUserID(params.userid)
 

--- a/scripts/vscripts/popextensions_main.nut
+++ b/scripts/vscripts/popextensions_main.nut
@@ -132,6 +132,7 @@ if (!("_AddThinkToEnt" in _root))
 	}
 	Events = {
 		function OnGameEvent_post_inventory_application(params) {
+			if (GetRoundState() == GR_STATE_PREROUND) return
 
 			local player = GetPlayerFromUserID(params.userid)
 
@@ -195,8 +196,7 @@ if (!("_AddThinkToEnt" in _root))
 			PopExtMain.PlayerCleanup(player)
 		}
 
-		function OnGameEvent_recalculate_holidays(_) {
-			if (GetRoundState() != GR_STATE_PREROUND) return
+		function OnGameEvent_teamplay_round_start(_) {
 
 			//clean up all wearables that are not owned by a player or a bot
 			for (local wearable; wearable = FindByClassname(wearable, "tf_wearable*");)


### PR DESCRIPTION
Temporarily reverts a change made to accommodate wave init event order in order to fix a code race.

In future, we should move away from having multiple event definitions that can conflict with one another in this manner as it may lead to more race conditions outside of this particular instance, before re-applying the original change in #63 .