### PR TITLE
Fix explosive bullets working randomly

### DIFF
--- a/scripts/vscripts/popextensions/customattributes.nut
+++ b/scripts/vscripts/popextensions/customattributes.nut
@@ -1009,7 +1009,7 @@
 
 			scope.ItemThinkTable[format("ExplosiveBullets_%d_%d", player.GetScriptScope().userid,  wep.entindex())] <- function() {
 
-				if (!("explosive bullets" in player.GetScriptScope().attribinfo) || player.GetActiveWeapon() != wep || scope.explosivebulletsnextattack == GetPropFloat(wep, "m_flLastFireTime") || ("curclip" in scope && scope.curclip != wep.Clip1())) return
+				if (!("explosive bullets" in player.GetScriptScope().attribinfo) || player.GetActiveWeapon() != wep || scope.explosivebulletsnextattack == GetPropFloat(wep, "m_flLastFireTime")) return
 
 				local grenade = CreateByClassname("tf_projectile_pipe")
 				SetPropEntity(grenade, "m_hOwnerEntity", launcher)


### PR DESCRIPTION
Removed "("curclip" in scope && scope.curclip != wep.Clip1()" from explosive bullets, so weapons with the attribute will properly have bullets explode per shot.

I know this is due for a rewrite but let it work as it's written for now.