### PR TITLE
globalfixes legacy support

### DIFF
--- a/scripts/vscripts/popextensions/globalfixes.nut
+++ b/scripts/vscripts/popextensions/globalfixes.nut
@@ -24,6 +24,9 @@ if (GlobalFixesEntity == null) GlobalFixesEntity = SpawnEntityFromTable("info_te
 				projectile.AddEFlags(EFL_USER)
 			}
 		}
+
+		function DragonsFuryFix() { return }
+		function FastNPCUpdate() { return }
 	}
 
 	SpawnHookTable = {
@@ -75,6 +78,26 @@ if (GlobalFixesEntity == null) GlobalFixesEntity = SpawnEntityFromTable("info_te
 		// 	}
 		// }
 
+		function ScoutBetterMoneyCollection() { return }
+		function RemoveYERAttribute() { return }
+		function HoldFireUntilFullReloadFix() { return }
+		function EngineerBuildingPushbackFix() { return }
+
+	}
+
+	InitWaveTable = {}
+
+	TakeDamageTable = {
+		function YERDisguiseFix() { return }
+		function LooseCannonFix() { return }
+		function BotGibFix() { return }
+		function HolidayPunchFix() { return }
+	}
+
+	DisconnectTable = {}
+
+	DeathHookTable = {
+		function NoCreditVelocity() { return }
 	}
 
 	Events = { function GameEvent_mvm_wave_complete(params) { delete GlobalFixes } }

--- a/scripts/vscripts/popextensions_main.nut
+++ b/scripts/vscripts/popextensions_main.nut
@@ -178,7 +178,7 @@ if (!("_AddThinkToEnt" in _root))
 			}
 
 			if ("MissionAttributes" in _root) foreach (_, func in MissionAttributes.SpawnHookTable) func(params)
-			if ("GlobalFixes" in _root) foreach (_, func in GlobalFixes.SpawnHookTable) func(params)
+			// if ("GlobalFixes" in _root) foreach (_, func in GlobalFixes.SpawnHookTable) func(params)
 			if ("CustomAttributes" in _root) foreach (_, func in CustomAttributes.SpawnHookTable) func(params)
 			if ("PopExtPopulator" in _root) foreach (_, func in PopExtPopulator.SpawnHookTable) func(params)
 			if ("CustomWeapons" in _root) foreach (_, func in CustomWeapons.SpawnHookTable) func(params)


### PR DESCRIPTION
A really temporary fix into legacy support regarding the recent change of globalfixes.

All of the table keyvals are reimplemented as empty ones, so that other missions won't outright break when trying to delete / disable them (hopefully)

I also disabled post_inventory_application for globalfixes since I noticed right now GlobalFixes.SpawnHookTable is esssentially empty, and leaving that hook running will break this shitfix lol

Tested with red ridge, things should run properly