### PR TITLE
Nested tables support in robot tags

### DIFF
--- a/scripts/vscripts/popextensions/tags.nut
+++ b/scripts/vscripts/popextensions/tags.nut
@@ -1680,7 +1680,7 @@ local popext_funcs = {
 
 		local separator = tag.find("{") ? "{" : "|"
 
-		local splittag = split(tag, separator)
+		local splittag = separator == "{" ? PopExtUtil.splitonce(tag, separator) : split(tag, separator)
 
 		if (separator ==  "|")
 		{

--- a/scripts/vscripts/popextensions/util.nut
+++ b/scripts/vscripts/popextensions/util.nut
@@ -1438,6 +1438,19 @@
 		return finalResult;
 	}
 
+	// Python's string.partition(), except the separator itself is not returned
+	// Basically like calling python's string.split(sep, 1), notice the 1 meaning to only split once
+	function splitonce(s, sep = null)
+	{
+		if (sep == null) return [s, null]
+
+		local pos = s.find(sep)
+		local result_left = pos == 0 ? null : s.slice(0, pos)
+		local result_right = pos == s.len() - 1 ? null : s.slice(pos + 1)
+
+		return [result_left, result_right]
+	}
+
 	function EndWaveReverse(doteamswitch = true)
 	{
 		local temp = CreateByClassname("info_teleport_destination")


### PR DESCRIPTION
Nesting tables in tags is now possible. Tags that garner nested table arguments should be updated accordingly to properly utilise this function.

This basically leverages on the python `string.split(separator, maxsplit)` function with maxsplit set to 1, meaning that `split()` will only split once instead of splitting at every occurrence. This is named `splitonce()` in util.nut, as Squirrel's built-in split doesn't support this parameter.

Normal tags should be unaffected by this change.