### PR TITLE
Adding attributes to weapons from `popext_giveweapon` support

### DIFF
--- a/scripts/vscripts/popextensions/tags.nut
+++ b/scripts/vscripts/popextensions/tags.nut
@@ -856,18 +856,23 @@ local popext_funcs = {
 		}
 	}
 
-    /*****************************************************************************************************************************
-     * SIMPLE GIVEWEAPON                                                                                                         *
-     *                                                                                                                           *
-     * THIS DOES NOT WORK WITH CUSTOM WEAPONS!!!                                                                                 *
-     *                                                                                                                           *
-     * You can technically give bots cosmetics using this function as well, but it's not recommended and the syntax is different *
-     * Use PopExtUtil.CreatePlayerWearable instead                                                                               *
-     *                                                                                                                           *
-     * Add this to a pyro bot to give them a family business                                                                     *
-     *                                                                                                                           *
-     * Example: popext_giveweapon{ weapon = `tf_weapon_shotgun_pyro` id = 425 }                                                  *
-     *****************************************************************************************************************************/
+    /********************************************************************************************************************************************************
+     * SIMPLE GIVEWEAPON                                                                                                                                    *
+     *                                                                                                                                                      *
+     * THIS DOES NOT WORK WITH CUSTOM WEAPONS!!!                                                                                                            *
+     *                                                                                                                                                      *
+     * You can technically give bots cosmetics using this function as well, but it's not recommended and the syntax is different                            *
+     * Use PopExtUtil.CreatePlayerWearable instead                                                                                                          *
+     *                                                                                                                                                      *
+     * Add this to a pyro bot to give them a family business                                                                                                *
+     *                                                                                                                                                      *
+     * Example: popext_giveweapon{ weapon = `tf_weapon_shotgun_pyro` id = 425 }                                                                             *
+	 *                                                                                                                                                      *
+	 * You can also give extra attributes to the given weapons by writing the tag like this,                                                                *
+	 * Example: Give a scout bot the pomson with +40% firing speed and +180% faster reload time                                                             *
+	 *          popext_giveweapon{ weapon = `tf_weapon_drg_pomson`, id = ID_POMSON_6000, attrs = { `fire rate bonus`: 0.6, `faster reload rate`: -0.8 } }   *
+	 * These added attributes display properly on spectator inspection.                                                                                     *
+     ********************************************************************************************************************************************************/
 
 	popext_giveweapon = function(bot, args) {
 
@@ -881,6 +886,12 @@ local popext_funcs = {
 		PopExtUtil.GetItemInSlot(bot, weapon.GetSlot()).Destroy()
 
 		bot.Weapon_Equip(weapon)
+
+		if ("attrs" in args)
+		{
+			foreach (k, v in args.attrs)
+				weapon.AddAttribute(k, v, -1)
+		}
 
 		return weapon
 	}


### PR DESCRIPTION
You are able to directly give attributes to given weapons in the tag instead of having to workaround and specify them in `CharacterAttributes` now